### PR TITLE
Properly parse empty fields

### DIFF
--- a/src/classes/CSVReader.cls
+++ b/src/classes/CSVReader.cls
@@ -127,7 +127,7 @@ public class CSVReader {
         terminatorSet.add(NL);
         terminatorSet.add(null);
 
-        do {
+        while(!terminatorSet.contains(this.tokenString) || (isQuoteMode == true)) {
            if(isQuoteMode){
                 if((this.tokenString == QUOTE) && (this.lookAheadString == QUOTE)){
                     returnValue = returnValue + QUOTE;
@@ -151,7 +151,7 @@ public class CSVReader {
 
            }
 
-        } while(!terminatorSet.contains(this.tokenString) || (isQuoteMode == true));
+        }
 
 
         return returnValue;

--- a/src/classes/CSVReader_Test.cls
+++ b/src/classes/CSVReader_Test.cls
@@ -40,5 +40,16 @@ public class CSVReader_Test {
 
     }
 
+    static testMethod  void testZeroWidthValues() {
+      String inputString = 'Id,Name,Description,Other\n' +
+                           '123,,"I like Freder\nick",""\n';
+      CSVReader internalReader = new CSVReader(inputString, true);
+      System.assertEquals('123', internalReader.listOfMaps[0].get('Id'));
+      System.assertEquals('', internalReader.listOfMaps[0].get('Name'));
+      System.assertEquals('I like Freder\nick', internalReader.listOfMaps[0].get('Description'));
+      System.assertEquals('', internalReader.listOfMaps[0].get('Other'));
+      
+    }
+
 
 }


### PR DESCRIPTION
In the current code, "ABC,,DEF" parses as two fields, `"ABC"`, and `",DEF"`.

This PR changes properly parses three fields: `"ABC"`, `""`, and `"DEF"`.